### PR TITLE
Reconsider available filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,12 +124,8 @@
             <label for="head-filter">Filter</label>
             <select id="head-filter">
               <option value="none">None</option>
-              <option value="gray">Gray</option>
               <option value="blur">Blur</option>
               <option value="monochrome">Monochrome</option>
-              <option value="pixelate">Pixellate</option>
-              <option value="cartoon">Cartoon</option>
-              <option value="outline">Hidden</option>
             </select>
           </div>
         </div>
@@ -254,8 +250,8 @@
             <select id="target-filter" disabled>
               <option value="none">None</option>
               <option value="sharpen">Sharpen</option>
-              <option value="pixelate">Pixelate</option>
               <option value="gray">Gray</option>
+              <option value="nowhite">Remove white</option>
             </select>
           </div>
         </div>

--- a/index.js
+++ b/index.js
@@ -2073,97 +2073,37 @@ const entityBeingEdited = dom['entity-being-edited'],
 scrawl.makeFilter({
   name: 'none',
   actions: [],
-}),
+});
 
 scrawl.makeFilter({
   name: 'blur',
   method: 'gaussianBlur',
   radius: 20,
   excludeTransparentPixels: true,
-}),
+});
 
 scrawl.makeFilter({
   name: 'gray',
   method: 'grayscale',
-}),
-
-scrawl.makeFilter({
-  name: 'pixelate',
-  method: 'pixelate',
-  tileWidth: 20,
-  tileHeight: 20,
-}),
+});
 
 scrawl.makeFilter({
   name: 'monochrome',
   method: 'reducePalette',
   noiseType: 'bluenoise',
-}),
+});
 
 scrawl.makeFilter({
   name: 'sharpen',
   method: 'sharpen',
-}),
-
-scrawl.makeFilter({
-  name: 'outline',
-  method: 'flood',
-  reference: 'gray',
-  opacity: 0.95,
 });
 
 scrawl.makeFilter({
-  name: 'cartoon',
-  actions: [
-    {
-      action: 'grayscale',
-      lineOut: 'top-filter-1',
-    },{
-      lineIn: 'top-filter-1',
-      action: 'gaussian-blur',
-      radius: 1,
-      lineOut: 'top-filter-1',
-    },{
-      lineIn: 'top-filter-1',
-      action: 'matrix',
-      weights: [1, 1, 1, 1, -8, 1, 1, 1, 1],
-      lineOut: 'top-filter-2',
-    },{
-      lineIn: 'top-filter-2',
-      action: 'channels-to-alpha',
-      lineOut: 'top-filter-2',
-    },{
-      lineIn: 'top-filter-2',
-      action: 'threshold',
-      low: [0, 0, 0, 0],
-      high: [0, 0, 0, 255],
-      includeAlpha: true,
-      level: 20,
-      lineOut: 'top-filter-2',
-    },{
-      lineIn: 'source',
-      action: 'step-channels',
-      red: 15,
-      green: 60,
-      blue: 60,
-      lineOut: 'bottom-filter',
-    },{
-      lineIn: 'bottom-filter',
-      action: 'modulate-channels',
-      red: 2,
-      green: 2,
-      blue: 2,
-      alpha: 0.5,
-      lineOut: 'bottom-filter',
-    },{
-      lineIn: 'top-filter-2',
-      lineMix: 'bottom-filter',
-      action: 'compose',
-      compose: 'source-over',
-    }
-  ],
+  name: 'nowhite',
+  method: 'chroma',
+  ranges: [[250, 250, 250, 255, 255, 255]],
+  feather: 40,
 });
-
 
 // ------------------------------------------------------------------------
 // Start the page running
@@ -2177,7 +2117,6 @@ canvas.set({
 });
 
 const {
-  getScribblesFlag,
   setScribblesFlag,
   updateAllScribbles,
 } = initScribble();
@@ -2230,3 +2169,4 @@ scrawl.makeRender({
 // ------------------------------------------------------------------------
 DeviceManager.refreshDevices();
 
+console.log(scrawl.library);


### PR DESCRIPTION
Just cleaning up the graphical filters, to remove unnecessary ones.

Also added a new filter which will remove near-white colors from a target's display:
- This may be useful for creating titles and text while recording a video
- For instance:
  - Open a new Google Doc
  - Add some text to the page (say in the middle of the page
  - Capture the doc tab/window as a target
  - Apply the "Remove white" filter to get rid of the background
  - Now you have text in the canvas, which can be animated either in the tool, or in the Google doc window (for instance, highlights, change text colors, scroll up/down, etc